### PR TITLE
fix: remove string values from `ignorePatterns` if they exist

### DIFF
--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -50,6 +50,24 @@ const compileConfigCode = (fileCode: string): ESLint.Linter.Config => {
 const createCliEngineCache = new Map<string, ESLint.CLIEngine>();
 
 const createCLIEngine = (config: ESLint.Linter.Config): ESLint.CLIEngine => {
+  const extraConfig: ESLint.Linter.Config = {
+    parserOptions: {
+      ...config.parserOptions,
+      project: require.resolve('../../tsconfig.fake.json'),
+      projectFolderIgnoreList: []
+    }
+  };
+
+  if (config.ignorePatterns) {
+    const patterns = Array.isArray(config.ignorePatterns)
+      ? config.ignorePatterns
+      : [config.ignorePatterns];
+
+    extraConfig.ignorePatterns = patterns.filter(
+      pattern => typeof pattern !== 'string'
+    );
+  }
+
   return getsertCache(
     createCliEngineCache,
     JSON.stringify(config),
@@ -62,11 +80,7 @@ const createCLIEngine = (config: ESLint.Linter.Config): ESLint.CLIEngine => {
         envs: ['node'],
         baseConfig: {
           ...config,
-          parserOptions: {
-            ...config.parserOptions,
-            project: require.resolve('../../tsconfig.fake.json'),
-            projectFolderIgnoreList: []
-          }
+          ...extraConfig
         }
       }),
     'createCLIEngine'

--- a/test/src/rules/no-invalid-config.spec.ts
+++ b/test/src/rules/no-invalid-config.spec.ts
@@ -223,12 +223,12 @@ ruleTester.run('InvalidRuleConfig', rule, {
           {
             files: ['*.tsx'],
             rules: {
-              camelcase: ['error', { allow: ['child_process'] }],
+              'no-global-assign': ['error', { exceptions: ['MyGlobal'] }],
             }
           }
         ],
         rules: {
-          camelcase: ['error', { allow: ['child_process'] }],
+          'no-global-assign': ['error', { exceptions: ['MyGlobal'] }],
         }
       };
     `
@@ -258,16 +258,16 @@ ruleTester.run('InvalidRuleConfig', rule, {
       code: dedent`
         module.exports = {
           rules: {
-            [\`camelcase\`]: ['error', { ignore: ['child_process'] }],
+            [\`no-global-assign\`]: ['error', { allow: ['MyGlobal'] }],
           }
         };
       `,
       errors: [
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '',
           line: 3,
           column: 6
@@ -278,16 +278,16 @@ ruleTester.run('InvalidRuleConfig', rule, {
       code: dedent`
         module.exports = {
           rules: {
-            camelcase: ['error', { ignore: ['child_process'] }],
+            'no-global-assign': ['error', { allow: ['MyGlobal'] }],
           }
         };
       `,
       errors: [
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '',
           line: 3,
           column: 5
@@ -304,7 +304,7 @@ ruleTester.run('InvalidRuleConfig', rule, {
                 {
                   files: ['*'],
                   rules: {
-                    camelcase: ['error', { ignore: ['child_process'] }]
+                    'no-global-assign': ['error', { allow: ['MyGlobal'] }],
                   }
                 }
               ]
@@ -315,9 +315,9 @@ ruleTester.run('InvalidRuleConfig', rule, {
       errors: [
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '',
           line: 9,
           column: 13
@@ -331,30 +331,30 @@ ruleTester.run('InvalidRuleConfig', rule, {
             {
               files: ['*.tsx'],
               rules: {
-                camelcase: ['error', { ignore: ['child_process'] }],
+                'no-global-assign': ['error', { allow: ['MyGlobal'] }],
               }
             }
           ],
           rules: {
-            camelcase: ['error', { ignore: ['child_process'] }],
+            'no-global-assign': ['error', { allow: ['MyGlobal'] }],
           }
         };
       `,
       errors: [
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '',
           line: 6,
           column: 9
         }),
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '#overrides[0]',
           line: 11,
           column: 5
@@ -368,30 +368,30 @@ ruleTester.run('InvalidRuleConfig', rule, {
             {
               files: ['*.tsx'],
               rules: {
-                camelcase: ['error', { ignore: ['child_process'] }],
+                'no-global-assign': ['error', { allow: ['MyGlobal'] }],
               }
             }
           ],
           rules: {
-            camelcase: ['error', { allow: ['child_process'] }],
+            'no-global-assign': ['error', { exceptions: ['MyGlobal'] }],
           }
         };
       `,
       errors: [
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '',
           line: 6,
           column: 9
         }),
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '#overrides[0]',
           line: 11,
           column: 5
@@ -405,30 +405,30 @@ ruleTester.run('InvalidRuleConfig', rule, {
             {
               files: ['*.tsx'],
               rules: {
-                camelcase: ['error', { allow: ['child_process'] }],
+                'no-global-assign': ['error', { exceptions: ['MyGlobal'] }],
               }
             }
           ],
           rules: {
-            camelcase: ['error', { ignore: ['child_process'] }],
+            'no-global-assign': ['error', { allow: ['MyGlobal'] }],
           }
         };
       `,
       errors: [
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '',
           line: 6,
           column: 9
         }),
         expectedError({
           type: ESLintErrorType.InvalidRuleConfig,
-          ruleId: 'camelcase',
+          ruleId: 'no-global-assign',
           reason:
-            '\n\tValue {"ignore":["child_process"],"ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.',
+            '\n\tValue {"allow":["MyGlobal"]} should NOT have additional properties.',
           path: '#overrides[0]',
           line: 11,
           column: 5

--- a/test/src/rules/no-invalid-config.spec.ts
+++ b/test/src/rules/no-invalid-config.spec.ts
@@ -26,6 +26,8 @@ ruleTester.run('no-invalid-config', rule, {
   valid: [
     'module.exports = undefined;',
     'module.exports = "";',
+    'module.exports = { ignorePatterns: ["node_modules/"] }',
+    'module.exports = { ignorePatterns: "node_modules/" }',
     dedent`
       const { files } = require('./package.json');
 
@@ -744,6 +746,21 @@ ruleTester.run('InvalidConfig', rule, {
           type: ESLintErrorType.InvalidConfig,
           reason:
             '\n\t- "overrides[0]" should have required property \'files\'. Value: {"extends":["eslint:recommended"]}.',
+          line: 1,
+          column: 1
+        })
+      ]
+    },
+    {
+      code: 'module.exports = { ignorePatterns: [1] }',
+      errors: [
+        expectedError({
+          type: ESLintErrorType.InvalidConfig,
+          reason: [
+            '\n\t- Property "ignorePatterns" is the wrong type (expected string but got `[1]`).',
+            '\n\t- Property "ignorePatterns[0]" is the wrong type (expected string but got `1`).',
+            '\n\t- "ignorePatterns" should match exactly one schema in oneOf. Value: [1].'
+          ].join(''),
           line: 1,
           column: 1
         })


### PR DESCRIPTION
It seems that `ignorePatterns` has some interesting concepts around how `!` works - this was the only way I could get supporting configs that use `ignorePatterns` which include `node_modules/`, since we use `lib/blank.js` for our linting target.